### PR TITLE
Draft about a MirageOS as a proxy for a SOCKS4 service

### DIFF
--- a/examples/mirage/README.md
+++ b/examples/mirage/README.md
@@ -1,0 +1,41 @@
+## A MirageOS proxy to a SOCKS4 server
+
+This unikernel provide an HTTP(S) proxy which transmits any requests a SOCKS4
+server. For instance, we will use Tor which provides such service for us. We
+need to install Tor:
+```sh
+$ sudo apt update && sudo apt upgrade
+$ sudo apt install tor
+```
+
+By default, Tor initiates a server on \*:9050. You can check it via:
+```sh
+$ ss -nlt
+State    Recv-Q   Send-Q     Local Address:Port     Peer Address:Port  Process
+LISTEN   0        4096           127.0.0.1:9050          0.0.0.0:*
+```
+
+Then, you need to compile and run the unikernel:
+```sh
+$ cd examples/mirage
+$ opam install mirage
+$ mirage configure -t unix
+$ make depends
+$ mirage build
+```
+
+Finally, you just need to launch the executable:
+```sh
+$ ./example --socks4-hostname localhost --socks4-port 9050
+```
+
+By default, the MirageOS runs on \*:8080 but you can change it via the `--port`
+option. Finally, you can configure your favorite webbrowser to use as the
+HTTP and HTTPS proxy: 127.0.0.1:8080. You can directly check the result if you
+compare these commands:
+```sh
+$ curl -x localhost:8080 https://api.ipify.org ; echo
+a.b.c.d
+$ curl https://api.ipify.org ; echo
+e.f.g.h
+```

--- a/examples/mirage/config.ml
+++ b/examples/mirage/config.ml
@@ -17,19 +17,9 @@ let socks4_port =
   let doc = Key.Arg.info ~doc:"SOCKS4 port." [ "socks4-port" ] in
   Key.(create "socks4_port" Arg.(opt int 1080 doc))
 
-let tls_key_fingerprint =
-  let doc = Key.Arg.info ~doc:"The fingerprint of the TLS key." [ "tls-key-fingerprint" ] in
-  Key.(create "tls_key_fingerprint" Arg.(opt (some string) None doc))
-
-let tls_cert_fingerprint =
-  let doc = Key.Arg.info ~doc:"The fingerprint of the TLS certificate." [ "tls-cert-fingerprint" ] in
-  Key.(create "tls_cert_fingerprint" Arg.(opt (some string) None doc))
-
 let main = foreign
   ~keys:[ Key.abstract socks4_hostname
-        ; Key.abstract socks4_port
-        ; Key.abstract tls_key_fingerprint
-        ; Key.abstract tls_cert_fingerprint ]
+        ; Key.abstract socks4_port ]
   ~packages "Unikernel.Main"
   (random @-> time @-> mclock @-> pclock @-> stackv4v6 @-> job)
 

--- a/examples/mirage/config.ml
+++ b/examples/mirage/config.ml
@@ -1,13 +1,44 @@
 open Mirage
 
 let packages = [ package "socks"
-               ; package "mirage_socks4" ]
+               ; package "mirage_socks4"
+               ; package "paf"
+               ; package "paf" ~sublibs:[ "mirage" ]
+               ; package "httpaf"
+               ; package "rresult"
+               ; package "hex"
+               ; package "happy-eyeballs-mirage" ]
 
-let main = foreign ~packages "Unikernel.Main" (stackv4 @-> job)
+let socks4_hostname =
+  let doc = Key.Arg.info ~doc:"SOCKS4 hostname." [ "socks4-hostname" ] in
+  Key.(create "socks4_hostname" Arg.(required string doc))
 
-let stack = generic_stackv4 default_network
+let socks4_port =
+  let doc = Key.Arg.info ~doc:"SOCKS4 port." [ "socks4-port" ] in
+  Key.(create "socks4_port" Arg.(opt int 1080 doc))
+
+let tls_key_fingerprint =
+  let doc = Key.Arg.info ~doc:"The fingerprint of the TLS key." [ "tls-key-fingerprint" ] in
+  Key.(create "tls_key_fingerprint" Arg.(opt (some string) None doc))
+
+let tls_cert_fingerprint =
+  let doc = Key.Arg.info ~doc:"The fingerprint of the TLS certificate." [ "tls-cert-fingerprint" ] in
+  Key.(create "tls_cert_fingerprint" Arg.(opt (some string) None doc))
+
+let main = foreign
+  ~keys:[ Key.abstract socks4_hostname
+        ; Key.abstract socks4_port
+        ; Key.abstract tls_key_fingerprint
+        ; Key.abstract tls_cert_fingerprint ]
+  ~packages "Unikernel.Main"
+  (random @-> time @-> mclock @-> pclock @-> stackv4v6 @-> job)
+
+let random = default_random
+let time = default_time
+let mclock = default_monotonic_clock
+let pclock = default_posix_clock
+let stackv4v6 = generic_stackv4v6 default_network
 
 let () =
-  register "example" [
-      main $ stack
-    ]
+  register "example"
+    [ main $ random $ time $ mclock $ pclock $ stackv4v6 ]

--- a/examples/mirage/config.ml
+++ b/examples/mirage/config.ml
@@ -17,9 +17,14 @@ let socks4_port =
   let doc = Key.Arg.info ~doc:"SOCKS4 port." [ "socks4-port" ] in
   Key.(create "socks4_port" Arg.(opt int 1080 doc))
 
+let port =
+  let doc = Key.Arg.info ~doc:"Port of the HTTP proxy." [ "port" ] in
+  Key.(create "port" Arg.(opt int 8080 doc))
+
 let main = foreign
   ~keys:[ Key.abstract socks4_hostname
-        ; Key.abstract socks4_port ]
+        ; Key.abstract socks4_port
+        ; Key.abstract port ]
   ~packages "Unikernel.Main"
   (random @-> time @-> mclock @-> pclock @-> stackv4v6 @-> job)
 

--- a/examples/mirage/unikernel.ml
+++ b/examples/mirage/unikernel.ml
@@ -166,7 +166,7 @@ module Main
 
   let start _random _time _mclock _pclock stackv4v6 =
     let happy_eyeballs = Happy_eyeballs.create stackv4v6 in
-    Paf.init ~port:8080 (Stack.tcp stackv4v6) >>= fun t ->
+    Paf.init ~port:(Key_gen.port ()) (Stack.tcp stackv4v6) >>= fun t ->
     let service = Paf.http_service ~error_handler
       (request_handler happy_eyeballs) in
     let `Initialized th = Paf.serve service t in th

--- a/examples/mirage/unikernel.ml
+++ b/examples/mirage/unikernel.ml
@@ -1,41 +1,238 @@
 open Lwt.Infix
 
-let (let*) a f = a >>= f
+let ( >>? ) = Lwt_result.bind
+let ( <.> ) = fun f g x -> f (g x)
 
-module Main (S: Mirage_stack.V4) = struct
-  module Proxy = Mirage_socks4.Make(S)
+module Httpaf_client_connection = struct
+  include Httpaf.Client_connection
 
-  let make_request host =
-    [ "GET / HTTP/1.1"
-    ; "Host: " ^ host
-    ; ""
-    ; "" ]
-    |> String.concat "\r\n"
-    |> Cstruct.of_string
+  let yield_reader _ = assert false
+  let next_read_operation t =
+    (next_read_operation t :> [ `Close | `Read | `Yield ])
+end
 
-  let send flow buf =
-    S.TCPV4.write flow buf >|=
-    Result.get_ok
+module Main
+  (Random : Mirage_random.S)
+  (Time : Mirage_time.S)
+  (Mclock : Mirage_clock.MCLOCK)
+  (Pclock : Mirage_clock.PCLOCK)
+  (Stack: Tcpip.Stack.V4V6)
+= struct
+  module Happy_eyeballs = Happy_eyeballs_mirage.Make (Random) (Time) (Mclock) (Pclock) (Stack)
 
-  let rec read_data flow =
-    S.TCPV4.read flow >>= function
-    | Ok (`Data b) ->
-       Logs.info (fun f -> f "read: %d bytes:\n%s" (Cstruct.length b) (Cstruct.to_string b));
-       read_data flow
-    | Ok `Eof -> S.TCPV4.close flow
+  module Socks4 = struct
+    include Mirage_socks4.Make (Stack.TCP)
 
-  let start s =
-    let proxy_addr = (Ipaddr.V4.of_string_exn "127.0.0.1", 9050) in
-    let proxy = Proxy.make s proxy_addr in
+    type endpoint = Stack.TCP.flow * Socks.Socks4.Request.addr * int
+    let connect (flow, addr, port) = client_of_flow flow addr port
+  end
 
-    let hostname = "torchdeedp3i2jigzjdmfpn5ttjhthh5wbmda2rr3jvqjg5p77c54dqd.onion" in
-    let* flow =
-      Proxy.connect proxy (`Domain hostname) 80 >|= function
-      | Ok flow -> flow
-      | Error _ -> failwith "Something went wrong"
+  module TLS = struct
+    include Tls_mirage.Make (Socks4)
+
+    type endpoint = Socks4.flow * [ `host ] Domain_name.t option * Tls.Config.client
+    let connect (flow, host, cfg) = client_of_flow cfg ?host flow
+  end
+
+  let _socks_edn, socks_protocol = Mimic.register ~name:"socks4" (module Socks4)
+  let _tls_edn, tls_protocol = Mimic.register ~name:"tls" (module TLS)
+
+  let transmit
+    : [ `read ] Httpaf.Body.t -> [ `write ] Httpaf.Body.t -> unit
+    = fun src dst ->
+      let rec on_eof () =
+        Httpaf.Body.close_writer dst ;
+        Httpaf.Body.close_reader src
+      and on_read buf ~off ~len =
+        Httpaf.Body.schedule_bigstring dst ~off ~len buf ;
+        Httpaf.Body.schedule_read src ~on_eof ~on_read in
+      Httpaf.Body.schedule_read src ~on_eof ~on_read
+
+  let transmit_tls
+    : Stack.TCP.flow -> Mimic.flow -> unit Lwt.t
+    = fun flow dst ->
+      let rec reader () = Stack.TCP.read flow >>= function
+        | Error err ->
+          Logs.err (fun m -> m "Got an error from the (reader) client: %a." Stack.TCP.pp_error err) ;
+          Lwt.return_unit
+        | Ok `Eof -> Lwt.return_unit
+        | Ok (`Data cs) -> Mimic.write dst cs >>= function
+          | Ok () -> Lwt.pause () >>= reader
+          | Error err ->
+            Logs.err (fun m -> m "Got an error from the (reader) destination: %a." Mimic.pp_write_error err) ;
+            Lwt.return_unit in
+      let rec writer () = Mimic.read dst >>= function
+        | Error err ->
+          Logs.err (fun m -> m "Got an error from the (writer) destination: %a." Mimic.pp_error err) ;
+          Lwt.return_unit
+        | Ok `Eof -> Lwt.return_unit
+        | Ok (`Data cs) -> Stack.TCP.write flow cs >>= function
+          | Ok () -> Lwt.pause () >>= writer
+          | Error err ->
+            Logs.err (fun m -> m "Got an error from the (writer) client: %a." Stack.TCP.pp_write_error err) ;
+            Lwt.return_unit in
+      Lwt.join [ reader (); writer () ] >>= fun () ->
+      Stack.TCP.close flow >>= fun () ->
+      Mimic.close dst
+
+  let response_handler reqd resp src =
+    let dst = Httpaf.Reqd.respond_with_streaming reqd resp in
+    transmit src dst
+
+  let create_connection_to_socks4 happy_eyeballs addr port =
+    let module Flow = (val Mimic.repr socks_protocol) in
+    Happy_eyeballs.connect happy_eyeballs
+      (Key_gen.socks4_hostname ())
+      [ Key_gen.socks4_port () ] >|= Rresult.R.open_error_msg >>? fun ((ipv4, _port), tcpv4v6) ->
+    Socks4.client_of_flow tcpv4v6 addr port
+    >|= Rresult.R.reword_error (Rresult.R.msgf "%a" Socks4.pp_write_error) >>? fun flow ->
+    Lwt.return_ok (Flow.T flow)
+
+  let create_tls_connection_to_socks4 cfg happy_eyeballs addr port =
+    (* let module Flow = (val Mimic.repr tls_protocol) in *)
+    let module Flow = (val Mimic.repr socks_protocol) in
+    Happy_eyeballs.connect happy_eyeballs
+      (Key_gen.socks4_hostname ())
+      [ Key_gen.socks4_port () ] >|= Rresult.R.open_error_msg >>? fun ((ipv4, _port), tcpv4v6) ->
+    Socks4.client_of_flow tcpv4v6 addr port
+    >|= Rresult.R.reword_error (Rresult.R.msgf "%a" Socks4.pp_write_error) >>? fun socks4 ->
+    Lwt.return_ok (Flow.T socks4)
+    (* let host = match addr with
+      | `IPv4 _ -> None
+      | `Domain str -> Rresult.(R.to_option Domain_name.(of_string str >>= host)) in
+    TLS.client_of_flow cfg ?host socks4
+    >|= Rresult.R.reword_error (Rresult.R.msgf "%a" TLS.pp_write_error) >>? fun flow ->
+    Lwt.return_ok (Flow.T flow) *)
+
+  let host_to_addr host =
+    let host, port = match String.split_on_char ':' host with 
+      | [ host; port ] ->
+        ( try host, int_of_string port
+          with _ -> host, 80 )
+      | _ -> host, 80 in
+    let addr = match Ipaddr.V4.of_string host with
+      | Ok ipaddr -> `IPv4 ipaddr
+      | Error _ -> `Domain host in
+    addr, port
+
+  let error_handler = function
+    | `Exn exn ->
+      Logs.err (fun m -> m "Exception from the client connection: %S" (Printexc.to_string exn))
+    | `Invalid_response_body_length response ->
+      Logs.err (fun m -> m "Invalid response body length")
+    | `Malformed_response err ->
+      Logs.err (fun m -> m "Malformed response: %s" err)
+
+  let request_handler cfg happy_eyeballs flow peer reqd =
+    let request = Httpaf.Reqd.request reqd in
+    let target =
+      let open Rresult.R in
+      Httpaf.Headers.get request.Httpaf.Request.headers "Host"
+      |> of_option ~none:(fun () -> error `Host_not_found)
+      >>| host_to_addr in
+    match target with
+    | Error `Host_not_found ->
+      Logs.err (fun m -> m "The request missed the Host parameter.")
+    | Ok (addr, port) ->
+      Lwt.async begin fun () -> 
+      Lwt.catch begin fun () -> match request.Httpaf.Request.meth with
+      | `CONNECT ->
+        ( create_tls_connection_to_socks4 cfg happy_eyeballs addr port >>= function
+        | Ok dst ->
+          let headers = Httpaf.Headers.of_list [ "connection", "close" ] in
+          let resp = Httpaf.Response.create ~headers `OK in
+          Httpaf.Reqd.respond_with_string reqd resp "" ;
+          Httpaf.Body.close_reader (Httpaf.Reqd.request_body reqd) ;
+          transmit_tls flow dst
+        | Error _ -> assert false )
+      | _meth ->
+        let dst, conn = Httpaf.Client_connection.request
+          ~error_handler:error_handler
+          ~response_handler:(response_handler reqd) request in
+        transmit (Httpaf.Reqd.request_body reqd) dst ;
+        create_connection_to_socks4 happy_eyeballs addr port >>= function
+        | Ok dst ->
+          Paf.run (module Httpaf_client_connection) ~sleep:Time.sleep_ns conn dst >>= fun () ->
+          Stack.TCP.close flow
+        | Error (`Msg err) ->
+          Logs.err (fun m -> m "Impossible to create a client connection: %s." err) ;
+          Lwt.return_unit
+      end @@ fun exn ->
+      Logs.err (fun m -> m "Got an exception while sending the HTTP request: %S" (Printexc.to_string exn)) ;
+      Lwt.return_unit
+      end
+
+  module Stack' = struct
+    module TCP = struct
+      include Stack.TCP
+
+      let close _ = Lwt.return_unit
+    end
+
+    module UDP = Stack.UDP
+    module IP = Stack.IP
+
+    type t = Stack.t
+    let disconnect = Stack.disconnect
+    let udp = Stack.udp
+    let tcp = Stack.tcp
+    let ip = Stack.ip
+    let listen_udp = Stack.listen_udp
+    let listen_tcp = Stack.listen_tcp
+    let listen = Stack.listen
+  end
+
+  module Paf = Paf_mirage.Make (Time) (Stack')
+
+  let of_fp str =
+    let hash, fp =
+      let hash_of_string = function
+        | "md5" -> Some `MD5
+        | "sha" | "sha1" -> Some `SHA1
+        | "sha224" -> Some `SHA224
+        | "sha256" -> Some `SHA256
+        | "sha384" -> Some `SHA384
+        | "sha512" -> Some `SHA512
+        | _ -> None
+      in
+      match String.split_on_char ':' str with
+      | [] -> Fmt.failwith "Invalid fingerprint %S" str
+      | [ fp ] -> `SHA256, fp
+      | hash :: rest -> (
+          match hash_of_string (String.lowercase_ascii hash) with
+          | Some hash -> hash, String.concat "" rest
+          | None -> Fmt.failwith "Invalid hash algorithm: %S" hash)
     in
-    let buf = make_request hostname in
-    let* () = send flow buf in
-    read_data flow
+    let fp =
+      try Hex.to_cstruct (`Hex fp)
+      with _ -> Fmt.failwith "Invalid hex fingerprint value: %S" fp
+    in
+    hash, fp
 
+  let authenticator () =
+    let time () = Some (Ptime.v (Pclock.now_d_ps ())) in
+    match Key_gen.tls_key_fingerprint (), Key_gen.tls_cert_fingerprint () with
+    | None, None ->
+      let module NSS = Ca_certs_nss.Make (Pclock) in
+      ( match NSS.authenticator () with
+      | Ok authenticator -> authenticator
+      | Error (`Msg err) -> failwith err )
+    | Some _, Some _ ->
+      failwith "You can not provide certificate and key fingerprint"
+    | Some fp, None ->
+      let hash, fingerprint = of_fp fp in
+      X509.Authenticator.server_key_fingerprint ~time ~hash ~fingerprint
+    | None, Some fp ->
+      let hash, fingerprint = of_fp fp in
+      X509.Authenticator.server_cert_fingerprint ~time ~hash ~fingerprint
+
+  let error_handler _peer ?request _err _respond = ()
+
+  let start _random _time _mclock _pclock stackv4v6 =
+    let happy_eyeballs = Happy_eyeballs.create stackv4v6 in
+    let cfg = Tls.Config.client ~authenticator:(authenticator ()) () in
+    Paf.init ~port:8080 (Stack.tcp stackv4v6) >>= fun t ->
+    let service = Paf.http_service ~error_handler
+      (request_handler cfg happy_eyeballs) in
+    let `Initialized th = Paf.serve service t in th
 end

--- a/lwt_unix/dune
+++ b/lwt_unix/dune
@@ -1,4 +1,4 @@
 (library
-  (name lwt_socks4_unix)
-  (public_name lwt_socks4_unix)
-  (libraries socks lwt.unix))
+ (name lwt_socks4_unix)
+ (public_name lwt_socks4_unix)
+ (libraries socks lwt.unix))

--- a/mirage_socks4.opam
+++ b/mirage_socks4.opam
@@ -14,6 +14,6 @@ depends: [
   "lwt"
   "dune"
   "ipaddr"
-  "mirage-stack" 
+  "mirage-flow"
 ]
 build: [ "dune" "build" "-p" name "-j" jobs ]

--- a/mirage_socks4/dune
+++ b/mirage_socks4/dune
@@ -1,4 +1,4 @@
 (library
-  (name mirage_socks4)
-  (public_name mirage_socks4)
-  (libraries socks mirage-stack))
+ (name mirage_socks4)
+ (public_name mirage_socks4)
+ (libraries socks mirage-flow))

--- a/mirage_socks4/mirage_socks4.ml
+++ b/mirage_socks4/mirage_socks4.ml
@@ -1,38 +1,34 @@
 open Socks
 open Lwt.Infix
 
-module Make (S: Tcpip.Stack.V4) = struct
-  type t = { tcpv4: S.TCPV4.t
-           ; proxy: Ipaddr.V4.t * int }
+let ( >>? ) = Lwt_result.bind
+
+module Make (Flow: Mirage_flow.S) = struct
+  type flow = { flow : Flow.flow
+              ; proxy : Socks4.Request.addr * int }
 
   type error =
-    [ `Connection of S.TCPV4.error
-    | `Read of S.TCPV4.error
-    | `Eof
-    | `Write of S.TCPV4.write_error
+    [ `Read of Flow.error
+    | `Write of Flow.write_error
     | `Socks4 of Socks4.Response.code ]
 
-  let make stack proxy =
-    { tcpv4 = S.tcpv4 stack
-    ; proxy }
+  type write_error = [ Mirage_flow.write_error | error ]
 
-  let create_connection ipv4 proxy_ip proxy_port =
-    S.TCPV4.create_connection ipv4 (proxy_ip, proxy_port) >|= function
-    | Ok flow -> Ok flow
-    | Error err -> Error (`Connection err)
+  let pp_error ppf = function
+    | `Read err -> Flow.pp_error ppf err
+    | `Write err -> Flow.pp_write_error ppf err
+    | `Socks4 code -> Fmt.pf ppf "Unexpected SOCKS4 code response: %a" Socks4.Response.pp code
 
-  let send_connection_request flow host port =
-    let buf = Socks4.Request.(to_cstruct (connect host port)) in
-    Lwt_result.map_err
-      (fun err -> `Write err)
-      (S.TCPV4.write flow buf)
+  let pp_write_error ppf = function
+    | #error as err -> pp_error ppf err
+    | #Mirage_flow.write_error as err -> Mirage_flow.pp_write_error ppf err
 
   let read count flow =
     let rec aux read bufs =
       if read < count then
-        S.TCPV4.read flow >>= function
+        Flow.read flow >>= function
         | Ok (`Data buf) -> aux (read + Cstruct.length buf) (buf :: bufs)
-        | Ok `Eof -> Lwt_result.fail `Eof
+        | Ok `Eof -> Lwt_result.fail `Closed
         | Error error -> Lwt_result.fail (`Read error)
       else
         Lwt_result.return bufs
@@ -44,14 +40,24 @@ module Make (S: Tcpip.Stack.V4) = struct
   let read_response flow =
     Lwt_result.map Socks4.Response.of_cstruct (read 8 flow)
 
-  let connect t host port =
-    let open Lwt_result.Infix in
-    let (proxy_ip, proxy_port) = t.proxy in
+  let send_connection_request flow host port =
+    let buf = Socks4.Request.(to_cstruct (connect host port)) in
+    Lwt_result.map_err
+      (fun err -> `Write err)
+      (Flow.write flow buf)
 
-    create_connection t.tcpv4 proxy_ip proxy_port >>= fun flow ->
-    send_connection_request flow host port >>= fun _ ->
-    read_response flow >>= fun response ->
+  let client_of_flow flow host port =
+    send_connection_request flow host port >>? fun () ->
+    read_response flow >>? fun response ->
     match response.Socks4.Response.code with
-    | `RequestGranted -> Lwt_result.return flow
+    | `RequestGranted -> Lwt_result.return { flow; proxy= host, port; }
     | error -> Lwt_result.fail (`Socks4 error)
+
+  let read { flow; _ } =
+    Lwt_result.map_err (fun err -> `Read err) (Flow.read flow)
+  let write { flow; _ } buf =
+    Lwt_result.map_err (fun err -> `Write err) (Flow.write flow buf)
+  let writev { flow; _ } buf =
+    Lwt_result.map_err (fun err -> `Write err) (Flow.writev flow buf)
+  let close { flow; _ } = Flow.close flow
 end

--- a/mirage_socks4/mirage_socks4.mli
+++ b/mirage_socks4/mirage_socks4.mli
@@ -1,15 +1,5 @@
+module Make (Flow: Mirage_flow.S) : sig
+  include Mirage_flow.S
 
-module Make (S: Tcpip.Stack.V4) : sig
-  type t
-
-  type error =
-    [ `Connection of S.TCPV4.error
-    | `Read of S.TCPV4.error
-    | `Eof
-    | `Write of S.TCPV4.write_error
-    | `Socks4 of Socks.Socks4.Response.code ]
-
-  val make : S.t -> Ipaddr.V4.t * int -> t
-
-  val connect : t -> Socks.Socks4.Request.addr -> int -> (S.TCPV4.flow, error) Lwt_result.t
+  val client_of_flow : Flow.flow -> Socks.Socks4.Request.addr -> int -> (flow, write_error) result Lwt.t
 end

--- a/socks/dune
+++ b/socks/dune
@@ -1,6 +1,7 @@
 (library
-  (name socks)
-  (public_name socks)
-  (modules socks4 socks)
-  (libraries cstruct ppx_cstruct lwt ipaddr ipaddr-cstruct)
-  (preprocess (pps ppx_cstruct)))
+ (name socks)
+ (public_name socks)
+ (modules socks4 socks)
+ (libraries fmt cstruct ppx_cstruct lwt ipaddr ipaddr-cstruct)
+ (preprocess
+  (pps ppx_cstruct)))

--- a/socks/socks4.ml
+++ b/socks/socks4.ml
@@ -74,6 +74,12 @@ module Response = struct
     | `RequestFailed
     | `RequestRejectedIdentd
     | `UserIdNotMatching ]
+
+  let pp ppf = function
+    | `RequestGranted -> Fmt.pf ppf "Request granted"
+    | `RequestFailed -> Fmt.pf ppf "Request failed"
+    | `RequestRejectedIdentd -> Fmt.pf ppf "Request rejected Identd"
+    | `UserIdNotMatching -> Fmt.pf ppf "User ID not matching"
  
   type t = { code: code
            ; ip: Ipaddr.V4.t

--- a/socks/socks4.mli
+++ b/socks/socks4.mli
@@ -72,6 +72,9 @@ module Response : sig
     | `UserIdNotMatching ]
   (** The response code from the request previously submitted. *)
 
+  val pp : code Fmt.t
+  (** Pretty-printer of {!val:code}. *)
+
   type t = { code: code
            ; ip: Ipaddr.V4.t
            ; port: int }

--- a/tests/dune
+++ b/tests/dune
@@ -1,3 +1,3 @@
 (test
-  (name test_socks4)
-  (libraries alcotest socks))
+ (name test_socks4)
+ (libraries alcotest socks))


### PR DESCRIPTION
This is a draft, we need to upgrade some software like `paf` to have the ability to manipulate the underlying socket and do the TLS proxy via the HTTP `CONNECT` request but it's working currently! I did a `dune build @fmt` too which formats `dune` files.